### PR TITLE
Find fix

### DIFF
--- a/BetterCredentials.psm1
+++ b/BetterCredentials.psm1
@@ -71,6 +71,10 @@ function Find-Credential {
 
             Returns all the credentials stored for windows' Remote Desktop client
         .EXAMPLE
+            Find-Credential *
+
+            Returns all the stored credentials for the user that were placed in the credential vault by BetterCredentials
+        .EXAMPLE
             Find-Credential | Where UserName -match User@Example.org
 
             Filters credentials to find everything for a specific username
@@ -100,6 +104,14 @@ function Test-Credential {
        Test-Credential UserName*
 
        A trailing asterisk is a wildcard character that matches zero or more characters at the end of the given user name.
+    .Example
+       Test-Credential *
+
+       An asterisk alone as the value of the UserName parameter returns true if there are any credentials in the credential vault that were placed there by BetterCredentials.
+    .Example
+       Test-Credential ''
+
+       An empty string value of the UserName parameter returns true if there are any credentials in the credential vault at all, whether or not placed there by BetterCredentials.
      .Notes
        History:
         v 4.4 Test-Credential added to BetterCredentials

--- a/CredentialManagement.cs
+++ b/CredentialManagement.cs
@@ -119,7 +119,7 @@ namespace CredentialManagement
             return target;
         }
 
-        public static PSObject[] Find(string filter = "")
+        public static PSObject[] Find(string filter = "", bool fix = true)
         {
             uint count = 0;
             int Flag = 0;
@@ -129,6 +129,8 @@ namespace CredentialManagement
             if(string.IsNullOrEmpty(filter)) {
                 filter = null;
                 Flag = 1;
+            } else if(fix) {
+                filter = FixTarget(filter);
             }
 
             NativeMethods.PSCredentialMarshaler helper = new NativeMethods.PSCredentialMarshaler();
@@ -143,7 +145,10 @@ namespace CredentialManagement
                 }
                 helper.CleanUpNativeData(credentialArray);
             } else {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+                int error = Marshal.GetLastWin32Error();
+                if( error != (int) NativeMethods.CREDErrorCodes.ERROR_NOT_FOUND ) {
+                    throw new Win32Exception(error);
+                }
             }
             return output;
         }

--- a/CredentialManagement.cs
+++ b/CredentialManagement.cs
@@ -194,13 +194,16 @@ namespace CredentialManagement
 
         public static PSObject Load(string target, CredentialType type = CredentialType.Generic, bool fix = true)
         {
-            PSObject cred;
+            PSObject cred = null;
             if(fix) {
                 target = FixTarget(target);
             }
 
             if(!NativeMethods.CredRead(target, type, 0, out cred)) {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+                int error = Marshal.GetLastWin32Error();
+                if( error != (int) NativeMethods.CREDErrorCodes.ERROR_NOT_FOUND ) {
+                    throw new Win32Exception(error);
+                }
             }
 
             return cred;


### PR DESCRIPTION
Test-Credential and Find-Credential don’t work as expected. The problem lies with the Find function in CredentialManagement.cs. Because CredWrite alters the names of credentials, you are using the function FixTarget to make this alteration transparent when credentials are retrieved. Thus FixTarget needs to be applied to the filter argument of the Find function to make that transparent as well.

Also in the Find function CredEnumerate returns false when it fails. In addition to some exception-worthy problems, the failure may be due to there being no credentials that pass the filter (ERROR_NOT_FOUND). In the case of ERROR_NOT_FOUND, the Find function should return a null result rather than throwing an exception.

Based on these changes I also added some additional examples for Test-Credential and Find-Credential.
