### PR TITLE
Hiding throw statement to make Get-Credential work correctly

### DIFF
--- a/CredentialManagement.cs
+++ b/CredentialManagement.cs
@@ -194,10 +194,6 @@ namespace CredentialManagement
                 target = FixTarget(target);
             }
 
-            if(!NativeMethods.CredRead(target, type, 0, out cred)) {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-
             return cred;
         }
 

--- a/CredentialManagement.cs
+++ b/CredentialManagement.cs
@@ -189,9 +189,16 @@ namespace CredentialManagement
 
         public static PSObject Load(string target, CredentialType type = CredentialType.Generic, bool fix = true)
         {
-            PSObject cred;
-            if(fix) {
+            if (fix)
+            {
                 target = FixTarget(target);
+            }
+
+            PSObject cred;
+            if (!NativeMethods.CredRead(target, type, 0, out cred))
+            {
+                //Dont do anything here - throwing causes false errors.
+                //throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 
             return cred;


### PR DESCRIPTION
this should resolve #11 and #9

It's not perfect - but I've tested every command with the throw statement removed and they all work.